### PR TITLE
Add bower support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bower_components

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,26 @@
+{
+  "name": "jquery-remove-upcase-accents",
+  "version": "1.1.1",
+  "homepage": "https://github.com/ebababi/jquery-remove-upcase-accents",
+  "authors": [
+    "Nikolaos Anastopoulos (http://anastopoulos.net/)"
+  ],
+  "description": "Automatically removes accented characters (currently greek) from elements having their text content uppercase transformed through CSS.",
+  "main": "jquery.remove-upcase-accents.js",
+  "keywords": [
+    "greek",
+    "accents",
+    "uppercase"
+  ],
+  "license": "GPLv3",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "jquery": "~2.1.3"
+  }
+}


### PR DESCRIPTION
I am using this plugin quite often and recently I started using [bower](http://bower.io/) to manage project dependencies. I thought it would be good if this plugin could be available at the bower package registry so that others (an me as well) can install it that way. 

In this commit there is everything that is necessary to allow for registering the repo as a bower package, except for actually registering it. You can do it by following the instructions [here](http://bower.io/docs/creating-packages/#register), or I can do it, if you don't want to install node, npm and bower on your machine. Thanks!
